### PR TITLE
Tell mirahc to build under dir to fix compile regression (GitHub #13)

### DIFF
--- a/templates/build.xml
+++ b/templates/build.xml
@@ -23,7 +23,7 @@
 
     <target name="compile" depends="-resource-src, -aidl, javac"
             description="Compiles project's .mirah files into .class files">
-        <mirahc src="${src}" destdir="${classes}">
+        <mirahc dir="${src}" destdir="${classes}">
             <classpath refid="java.classpath" />
         </mirahc>
     </target>


### PR DESCRIPTION
By changing 'src=${src}' to 'dir=${src}', mirahc now changes to the src directory and uses an implicit 'src=.'.  This seems to have resolved my issue  #13 .
