### PR TITLE
Use split Mirah/Java source directories if available.

### DIFF
--- a/lib/pindah.rb
+++ b/lib/pindah.rb
@@ -73,10 +73,33 @@ module Pindah
     File.open(build, "w") { |f| f.puts build_template.result(binding) }
     at_exit { File.delete build }
 
+    mirah_src_dir = File.join(@spec[:src], "mirah")
+    java_src_dir = File.join(@spec[:src], "java")
+    # check to see if there is a mirah subdirectory in the sources
+    if File.directory?(mirah_src_dir)
+      # if so, make sure a java source directory exists.  Otherwise, Ant will
+      # fail
+      unless File.exists?(java_src_dir)
+	puts "=== Creating empty Java source directory ==="
+	Dir.mkdir(java_src_dir)
+      end
+    else
+      # if not, print a warning and set both directories to be the one from the
+      # spec
+      puts "==== WARNING! =============================================="
+      puts "== You are now encouraged to place your source files in   =="
+      puts "== a mirah subdirectory, e.g. 'src/mirah' instead of      =="
+      puts "== 'src'.  Running in compatibility mode.                 =="
+      puts "============================================================"
+      java_src_dir = @spec[:src]
+      mirah_src_dir = @spec[:src]
+    end
+
     # TODO: add key signing config
     { "target" => "android-#{@spec[:target]}",
       "target-version" => "android-#{@spec[:target_version]}",
-      "src" => @spec[:src],
+      "source.dir" => java_src_dir, # Override default Java source directory
+      "src" => mirah_src_dir,
       "sdk.dir" => @spec[:sdk],
       "classes" => @spec[:classes],
       "classpath" => @spec[:classpath].join(Java::JavaLang::System::


### PR DESCRIPTION
This should address issue #15 (although I realise this request will create yet another issue).

As far as I can tell there is no really easy way to solve the problem without splitting source directories.  If I understand it correctly, you should not modify a signed package.  Unfortunately, for debug packages, packaging and signing are done in one step, and there is no chance to remove files.

So, I've created a patch that uses the same src parameter and checks for a 'mirah' subdirectory.  This is not the most robust way to do things, since this will break if someone has a 'mirah' top-level package.  However, I am guessing that should be rare.

If the mirah source directory exists, it makes sure a java source directory exists as well.  This keeps the build from breaking.

If no mirah source directory exists, it prints a nice warning and retains the old behaviour.

The parameters sent to Ant are slightly modified so that Android knows where to look for the Java directory.
