### PR TITLE
Fix gen directory name

### DIFF
--- a/templates/build.xml
+++ b/templates/build.xml
@@ -17,7 +17,7 @@
 
     <!-- TODO: better support for mixed-source builds -->
     <target name="javac" description="Compiles R.java and other gen/ files.">
-      <javac srcdir="gen" destdir="${classes}" 
+      <javac srcdir="${gen.dir}" destdir="${classes}"
              includeantruntime="false" failonerror="true" />
     </target>
 


### PR DESCRIPTION
'gen' might not be used as the directory name -- use ${gen.dir} to make sure we always get the right one.
