### PR TITLE
Respect ANDROID_HOME if set

### DIFF
--- a/lib/pindah.rb
+++ b/lib/pindah.rb
@@ -21,14 +21,11 @@ module Pindah
   VERSION = '0.1.2'
 
   def self.infer_sdk_location(path)
-    if ENV["ANDROID_HOME"] == "" then
-      tools = path.split(File::PATH_SEPARATOR).detect {|p| File.exists?("#{p}/android") || File.exists?("#{p}/android.bat") }
-      abort "\"android\" executable not found on $PATH" if tools.nil?
-      real_location = Pathname.new("#{tools}/android").realpath.dirname
-      File.expand_path("#{real_location}/..")
-    else
-      ENV["ANDROID_HOME"]
-    end
+    return ENV["ANDROID_HOME"] if ENV["ANDROID_HOME"] == nil
+    tools = path.split(File::PATH_SEPARATOR).detect {|p| File.exists?("#{p}/android") || File.exists?("#{p}/android.bat") }
+    abort "\"android\" executable not found on $PATH" if tools.nil?
+    real_location = Pathname.new("#{tools}/android").realpath.dirname
+    File.expand_path("#{real_location}/..")
   end
 
   DEFAULTS = { :output => File.expand_path("bin"),

--- a/lib/pindah.rb
+++ b/lib/pindah.rb
@@ -21,10 +21,14 @@ module Pindah
   VERSION = '0.1.2'
 
   def self.infer_sdk_location(path)
-    tools = path.split(File::PATH_SEPARATOR).detect {|p| File.exists?("#{p}/android") || File.exists?("#{p}/android.bat") }
-    abort "\"android\" executable not found on $PATH" if tools.nil?
-    real_location = Pathname.new("#{tools}/android").realpath.dirname
-    File.expand_path("#{real_location}/..")
+    if ENV["ANDROID_HOME"] == "" then
+      tools = path.split(File::PATH_SEPARATOR).detect {|p| File.exists?("#{p}/android") || File.exists?("#{p}/android.bat") }
+      abort "\"android\" executable not found on $PATH" if tools.nil?
+      real_location = Pathname.new("#{tools}/android").realpath.dirname
+      File.expand_path("#{real_location}/..")
+    else
+      ENV["ANDROID_HOME"]
+    end
   end
 
   DEFAULTS = { :output => File.expand_path("bin"),

--- a/lib/pindah.rb
+++ b/lib/pindah.rb
@@ -21,7 +21,7 @@ module Pindah
   VERSION = '0.1.2'
 
   def self.infer_sdk_location(path)
-    return ENV["ANDROID_HOME"] if ENV["ANDROID_HOME"].nil?
+    return ENV["ANDROID_HOME"] unless ENV["ANDROID_HOME"].nil?
     tools = path.split(File::PATH_SEPARATOR).detect {|p| File.exists?("#{p}/android") || File.exists?("#{p}/android.bat") }
     abort "\"android\" executable not found on $PATH" if tools.nil?
     real_location = Pathname.new("#{tools}/android").realpath.dirname

--- a/lib/pindah.rb
+++ b/lib/pindah.rb
@@ -21,7 +21,7 @@ module Pindah
   VERSION = '0.1.2'
 
   def self.infer_sdk_location(path)
-    return ENV["ANDROID_HOME"] if ENV["ANDROID_HOME"] == nil
+    return ENV["ANDROID_HOME"] if ENV["ANDROID_HOME"].nil?
     tools = path.split(File::PATH_SEPARATOR).detect {|p| File.exists?("#{p}/android") || File.exists?("#{p}/android.bat") }
     abort "\"android\" executable not found on $PATH" if tools.nil?
     real_location = Pathname.new("#{tools}/android").realpath.dirname


### PR DESCRIPTION
If the SDK path is determined like this, then it will be more user-friendly (I won't have to restructure my path just to get pindah to work).
