### PR TITLE
Compile Java files in src

### DIFF
--- a/templates/build.xml
+++ b/templates/build.xml
@@ -28,6 +28,13 @@
              target="1.6"
              includeantruntime="false"
              failonerror="true" />
+      <javac srcdir="${source.dir}"
+             destdir="${out.classes.absolute.dir}"
+             source="1.6"
+             target="1.6"
+             includeantruntime="false"
+             failonerror="true"
+             classpath="${java.classpath}:${sdk.dir}/platforms/${target}/android.jar" />
     </target>
 
     <target name="compile" depends="-compile" />


### PR DESCRIPTION
This lets mixed-source projects actually work (with Java files being compiled before Mirah files).
